### PR TITLE
исправление бага состояния поля ввода зарплаты

### DIFF
--- a/app/src/main/java/ru/practicum/android/diploma/filters/ui/views/FilterFragment.kt
+++ b/app/src/main/java/ru/practicum/android/diploma/filters/ui/views/FilterFragment.kt
@@ -102,7 +102,6 @@ class FilterFragment : Fragment() {
     }
 
     private fun setupSalaryInput() {
-
         val textWatcher = object : TextWatcher {
             override fun beforeTextChanged(s: CharSequence?, start: Int, count: Int, after: Int) {
                 val test = true

--- a/app/src/main/java/ru/practicum/android/diploma/filters/ui/views/FilterFragment.kt
+++ b/app/src/main/java/ru/practicum/android/diploma/filters/ui/views/FilterFragment.kt
@@ -22,7 +22,6 @@ class FilterFragment : Fragment() {
     private var _binding: FragmentFilterBinding? = null
     private val binding get() = _binding!!
     private val viewModel: FilterViewModel by inject()
-
     override fun onCreateView(
         inflater: LayoutInflater,
         container: ViewGroup?,
@@ -103,13 +102,14 @@ class FilterFragment : Fragment() {
     }
 
     private fun setupSalaryInput() {
+
         val textWatcher = object : TextWatcher {
             override fun beforeTextChanged(s: CharSequence?, start: Int, count: Int, after: Int) {
                 val test = true
             }
 
             override fun afterTextChanged(s: Editable?) {
-                if (s.toString().isNotEmpty()) {
+                if (s.toString().isNotEmpty() && s.toString().toLong() <= Int.MAX_VALUE) {
                     viewModel.setSalary(s.toString().toInt())
                 } else {
                     viewModel.setSalary(null)
@@ -139,6 +139,9 @@ class FilterFragment : Fragment() {
             viewModel.setInputSalaryState(hasFocus, binding.salaryEditText.text.isNullOrEmpty())
         }
 
+        binding.salaryEditText.setOnClickListener {
+            viewModel.setInputSalaryState(hasFocus = true, binding.salaryEditText.text.isNullOrEmpty())
+        }
     }
 
     @SuppressLint("ResourceAsColor", "ResourceType")

--- a/app/src/main/res/layout/fragment_filter.xml
+++ b/app/src/main/res/layout/fragment_filter.xml
@@ -5,8 +5,9 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:layout_marginHorizontal="@dimen/padding_16"
+    android:clickable="true"
+    android:focusableInTouchMode="true"
     android:orientation="vertical">
-
 
     <ImageButton
         android:id="@+id/btn_back"


### PR DESCRIPTION
Исправлена следующая ситуация:
если ввести зп, потом установить другой фильтра, очистить зп, установить другой фильтр - поле зп не меняла статус на "в фокусе", даже если на него нажать. Также нажатие на пустое пространство на экране не снимало фокус с поля ввода ЗП.